### PR TITLE
Exit with same return code as ansible-playbook

### DIFF
--- a/ansibletools/cli/ansible_local.py
+++ b/ansibletools/cli/ansible_local.py
@@ -28,4 +28,5 @@ import sys
 
 
 def main():
-    subprocess.call(['ansible-playbook', '-c', 'local', '-i', '127.0.0.1,'] + sys.argv[1:])
+    return_code = subprocess.call(['ansible-playbook', '-c', 'local', '-i', '127.0.0.1,'] + sys.argv[1:])
+    sys.exit(return_code)


### PR DESCRIPTION
ansible-local now exits with the same return code as ansible-playbook. Previously, ansible-local always exited with 0 regardless of the return code of ansible-playbook.
