### PR TITLE
Add an exception for ansible-vault command line argument order

### DIFF
--- a/ansibletools/__init__.py
+++ b/ansibletools/__init__.py
@@ -35,7 +35,11 @@ def wrap(cli):
     if helper_reports_error(helper_path):
         fatal("Unable to run ansible-vault-helper. Cannot continue.")
 
-    command = [sys.argv[1]] + ["--vault-password-file=%s" % helper_path] + sys.argv[2:]
+    # ansible-vault command expects the --vault-password-file argument to be after the action argument
+    if sys.argv[1] == "ansible-vault":
+        command = [sys.argv[1], sys.argv[2]] + ["--vault-password-file=%s" % helper_path] + sys.argv[3:]
+    else:
+        command = [sys.argv[1]] + ["--vault-password-file=%s" % helper_path] + sys.argv[2:]
     sys.exit(subprocess.call(command))
 
 


### PR DESCRIPTION
I am not sure whether this is compatible with older versions of ansible-vault. But it works at least with 2.9.3.